### PR TITLE
Added configuration to keep the viewbox; fixing IE scaling issues.

### DIFF
--- a/app.nw/script.js
+++ b/app.nw/script.js
@@ -3,7 +3,8 @@
     var FS = require('fs'),
         GUI = require('nw.gui'),
         SVGO = require('svgo'),
-        svgo = new SVGO(),
+        // Removing the view box causes scaling issues in IE
+        svgo = new SVGO({plugins:[{removeViewBox:false}]}),
         body = doc.body,
         holder = doc.querySelector('.holder'),
         list = doc.querySelector('.list'),


### PR DESCRIPTION
I added configuration that keeps the viewbox by default. Fixes [Issue #11](https://github.com/svg/svgo-gui/issues/11).
